### PR TITLE
chore(ios): raise minimum iOS version to 16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.3
+
+* raised the minimum iOS version to 16.0
+
 ## 4.4.2
 
 * removed unused Health Connect permissions to comply with the Google Play

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>14.0</string>
+  <string>16.0</string>
 </dict>
 </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '15.0'
+platform :ios, '16.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -41,7 +41,7 @@ post_install do |installer|
   installer.generated_projects.each do |project|
     project.targets.each do |target|
       target.build_configurations.each do |config|
-          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
       end
     end
   end

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -472,7 +472,7 @@
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "CARP Studies";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -587,7 +587,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -638,7 +638,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -664,7 +664,7 @@
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "CARP Studies";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -701,7 +701,7 @@
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "CARP Studies";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: The generic CARP study app.
 publish_to: "none"
 # Bump only the version name for a release; the `+N` build number is ignored by CI
 # (Fastlane auto-increments the Play versionCode; iOS uses the Xcode Cloud build number).
-version: 4.4.2+1
+version: 4.4.3+1
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
Bumps the app to **4.4.3** and raises the iOS floor to 16.0.

The three places that declare the minimum version had drifted apart — Podfile and `IPHONEOS_DEPLOYMENT_TARGET` said 15.0 while `AppFrameworkInfo.plist` still said 14.0. All three are now 16.0.

**SwiftPM stays off.** `enable-swift-package-manager: false` in `pubspec.yaml` is still required. See the blocker below.

## Verification

Branch as-is (SwiftPM off), clean build:

```
flutter build ipa --no-codesign
→ ✓ Built build/ios/archive/Runner.xcarchive (249.7MB)
  • Version Number: 4.4.3
  • Deployment Target: 16.0
```

`ios/Podfile.lock` churn from the local pod install was left out of this PR.

## Blocked: SwiftPM cannot be enabled yet

Flipping `enable-swift-package-manager: true` and running a clean `flutter build ipa` fails at archive time. Note this does **not** reproduce with `flutter build ios --no-codesign` — that path succeeds and hides the problem; the failure only appears in the full archive.

```
Target Integrity (Xcode): The package product 'carp-movesense-flutter' requires minimum platform version 15.0 for the iOS platform, but this target supports 13.0
Target Integrity (Xcode): The package product 'health'              requires minimum platform version 15.0 ... but this target supports 13.0
Target Integrity (Xcode): The package product 'screen-state'        requires minimum platform version 15.0 ... but this target supports 13.0
Target Integrity (Xcode): The package product 'light'               requires minimum platform version 14.0 ... but this target supports 13.0
Target Integrity (Xcode): The package product 'polar'               requires minimum platform version 14.0 ... but this target supports 13.0
```

Blocking packages, by required minimum:

| Package | Requires | Pulled in via |
| --- | --- | --- |
| `carp_movesense_flutter` 0.1.1 | iOS 15.0 | `carp_movesense_package` |
| `health` 13.3.2 | iOS 15.0 | `carp_health_package` |
| `screen_state` 5.0.2 | iOS 15.0 | `carp_mobile_sensing` |
| `light` 5.0.0 | iOS 14.0 | `carp_mobile_sensing` |
| `polar` 7.10.2 | iOS 14.0 | `carp_polar_package` |

### Why "target supports 13.0" when this PR sets 16.0

The 13.0 does not come from the Xcode project. Every `IPHONEOS_DEPLOYMENT_TARGET` in `project.pbxproj` is 16.0, the Podfile is 16.0, `AppFrameworkInfo.plist` is 16.0, and `xcodebuild -showBuildSettings` confirms `IPHONEOS_DEPLOYMENT_TARGET = 16.0`.

It comes from Flutter's generated SPM manifest, `ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift`, which is emitted with:

```swift
platforms: [
    .iOS("13.0")
],
```

`SwiftPackageManager.updateMinimumDeployment` (`flutter_tools/lib/src/ios/mac.dart:352`) is supposed to rewrite that from the project's build settings, but on Flutter 3.44.6 the manifest is still 13.0 after a clean regenerate. So the SPM platform floor never gets raised and every plugin above 13.0 trips Target Integrity.

Worth noting: the SwiftProtobuf duplicate-symbol clash between Polar (SPM) and Movesense (CocoaPods) — the reason originally recorded in the `pubspec.yaml` comment for keeping SwiftPM off — is **not** what fails today. That may have been fixed upstream, or it is simply masked because the build dies earlier at Target Integrity. It should be re-checked once the platform floor issue is resolved.

### Not blocking this PR

This PR ships with SwiftPM off, which archives cleanly. The above is what has to be solved before SwiftPM can be turned on in a follow-up.

Separately, these plugins still have no SPM support at all and keep CocoaPods in the build regardless: `audio_streamer`, `flutter_activity_recognition`, `flutter_sound`, `location`, `oidc_ios`, `open_settings_plus`.
