### PR TITLE
fix(consent): show consent once, and recover from a failed upload

### DIFF
--- a/assets/lang/da.json
+++ b/assets/lang/da.json
@@ -249,5 +249,6 @@
   "pages.home.retry": "Prøv igen",
   "pages.devices.connection.step.scan.searching": "Søger efter enheder i nærheden…\nSørg for, at din enhed er tændt og inden for rækkevidde.",
   "pages.devices.connection.step.scan.show_all": "Kan du ikke se din enhed? Vis alle",
-  "pages.devices.connection.step.scan.filtered": "Vis kun matchende enheder"
+  "pages.devices.connection.step.scan.filtered": "Vis kun matchende enheder",
+  "pages.informed_consent.upload_failed": "Dit samtykke kunne ikke gemmes. Tjek din internetforbindelse, og prøv igen."
 }

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -276,5 +276,6 @@
   "tasks.participant_data.phone_number.phone_number": "Phone No.",
   "tasks.participant_data.review.title": "Review",
   "pages.home.setup_failed": "Could not set up the study. Please check your internet connection and try again.",
-  "pages.home.retry": "Retry"
+  "pages.home.retry": "Retry",
+  "pages.informed_consent.upload_failed": "Could not save your consent. Please check your internet connection and try again."
 }

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -159,5 +159,6 @@
   "pages.devices.location_permission.message": "Conectarse a dispositivos Bluetooth cercanos requiere los permisos de Dispositivos cercanos y Ubicación. Para permitirlos, ve a: Ajustes → Apps → CARP Studies → Permisos, concede los permisos que falten e intenta conectarte de nuevo.",
   "pages.devices.connection.step.scan.searching": "Buscando dispositivos cercanos…\nAsegúrate de que tu dispositivo esté encendido y dentro del alcance.",
   "pages.devices.connection.step.scan.show_all": "¿No ves tu dispositivo? Mostrar todos",
-  "pages.devices.connection.step.scan.filtered": "Mostrar solo dispositivos coincidentes"
+  "pages.devices.connection.step.scan.filtered": "Mostrar solo dispositivos coincidentes",
+  "pages.informed_consent.upload_failed": "No se pudo guardar su consentimiento. Compruebe su conexión a internet e inténtelo de nuevo."
 }

--- a/lib/carp_study_app.dart
+++ b/lib/carp_study_app.dart
@@ -45,17 +45,20 @@ class CarpAppState extends State<CarpStudyApp> {
         return InvitationListPage.route;
       }
 
+      // 3) Consent not signed → the consent document. A redirect replaces the
+      // location, so - unlike a push - a router refresh cannot replay it.
+      final needsSigning = await bloc.appViewModel.informedConsentViewModel.needsSigning();
+      if (needsSigning) return InformedConsentPage.route;
+      if (loc == InformedConsentPage.route) return homeRoute;
+
       // 4) Fully onboarded.
       return null;
     },
     routes: <RouteBase>[
       ShellRoute(
         navigatorKey: _shellNavigatorKey,
-        builder: (BuildContext context, GoRouterState state, Widget child) => CarpAppShell(
-          model: bloc.appViewModel.homePageViewModel,
-          consentModel: bloc.appViewModel.informedConsentViewModel,
-          child: child,
-        ),
+        builder: (BuildContext context, GoRouterState state, Widget child) =>
+            CarpAppShell(model: bloc.appViewModel.homePageViewModel, child: child),
         routes: [
           // Just a landing slot - the redirect above moves the user on.
           GoRoute(path: homeRoute, parentNavigatorKey: _shellNavigatorKey, redirect: (_, _) => HomePage.route),
@@ -108,6 +111,12 @@ class CarpAppState extends State<CarpStudyApp> {
           child: ProfilePage(bloc.appViewModel.profilePageViewModel),
           transitionsBuilder: slideInFromRightAnimation,
         ),
+      ),
+      // Consent is not a tab - it replaces the whole app until it is signed.
+      GoRoute(
+        path: InformedConsentPage.route,
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => InformedConsentPage(model: bloc.appViewModel.informedConsentViewModel),
       ),
       GoRoute(
         path: StudyAboutPage.route,

--- a/lib/carp_study_app.dart
+++ b/lib/carp_study_app.dart
@@ -23,9 +23,7 @@ class CarpAppState extends State<CarpStudyApp> {
   /// Reload language translations and re-build the entire app.
   void reloadLocale() => setState(() => rpLocalizationsDelegate.reload());
 
-  // State-driven routing. Bloc state
-  // changes notify the router via refreshListenable, which re-evaluates the
-  // redirect at the current location and moves the user automatically.
+  // State-driven routing: a bloc change refreshes the router, which re-redirects.
   final GoRouter _router = GoRouter(
     initialLocation: homeRoute,
     navigatorKey: _rootNavigatorKey,
@@ -39,8 +37,7 @@ class CarpAppState extends State<CarpStudyApp> {
         return LoginPage.route;
       }
 
-      // 2) No study selected → user belongs on the invitation list (or its
-      // details page). Anywhere else gets bounced to the list.
+      // 2) No study → the invitation list (or its details page).
       if (!bloc.study.hasStudy) {
         if (loc == InvitationListPage.route || loc.startsWith('${InvitationDetailsPage.route}/')) {
           return null;
@@ -60,8 +57,7 @@ class CarpAppState extends State<CarpStudyApp> {
           child: child,
         ),
         routes: [
-          // Home is just a landing slot — the top-level redirect always moves
-          // the user to the right place based on bloc state.
+          // Just a landing slot - the redirect above moves the user on.
           GoRoute(path: homeRoute, parentNavigatorKey: _shellNavigatorKey, redirect: (_, _) => HomePage.route),
           GoRoute(
             path: HomePage.route,
@@ -81,8 +77,7 @@ class CarpAppState extends State<CarpStudyApp> {
               transitionsBuilder: bottomNavigationBarAnimation,
             ),
           ),
-          // HomePage is the new study landing page; keep /study as a redirect
-          // alias so any legacy navigation lands on the Home tab.
+          // /study is a legacy alias for the Home tab.
           GoRoute(path: StudyPage.route, parentNavigatorKey: _shellNavigatorKey, redirect: (_, _) => HomePage.route),
           GoRoute(
             path: StatisticsPage.route,
@@ -104,8 +99,7 @@ class CarpAppState extends State<CarpStudyApp> {
           ),
         ],
       ),
-      // Profile is not a bottom-nav tab - it slides in full-screen over the
-      // shell, so it lives on the root navigator.
+      // Profile slides in full-screen over the shell, so: root navigator.
       GoRoute(
         path: ProfilePage.route,
         parentNavigatorKey: _rootNavigatorKey,
@@ -114,13 +108,6 @@ class CarpAppState extends State<CarpStudyApp> {
           child: ProfilePage(bloc.appViewModel.profilePageViewModel),
           transitionsBuilder: slideInFromRightAnimation,
         ),
-      ),
-      // Consent escapes the shell (root navigator) so the bottom nav doesn't
-      // bleed through while the user is completing informed consent.
-      GoRoute(
-        path: InformedConsentPage.route,
-        parentNavigatorKey: _rootNavigatorKey,
-        builder: (context, state) => InformedConsentPage(model: bloc.appViewModel.informedConsentViewModel),
       ),
       GoRoute(
         path: StudyAboutPage.route,
@@ -168,8 +155,7 @@ class CarpAppState extends State<CarpStudyApp> {
     debugLogDiagnostics: true,
   );
 
-  /// Research Package translations, incl. both local language assets plus
-  /// translations of informed consent and surveys downloaded from CARP
+  /// RP translations: local language assets plus those downloaded from CARP.
   final RPLocalizationsDelegate rpLocalizationsDelegate = _AppLocalizationsDelegate(
     loaders: [const AssetLocalizationLoader(), bloc.resources.localizationLoader],
   );
@@ -189,8 +175,7 @@ class CarpAppState extends State<CarpStudyApp> {
     super.dispose();
   }
 
-  /// Re-load translations when a (new) study is set or has been configured,
-  /// since both make new study-specific translations available.
+  /// Re-load translations when a study is set or configured - both add new ones.
   void _onAppStateChanged() {
     final configured = bloc.state == AppState.configured;
     final deploymentId = bloc.study.study?.studyDeploymentId;
@@ -241,8 +226,7 @@ class CarpAppState extends State<CarpStudyApp> {
   }
 }
 
-/// Loads the RP translations and captures the loaded localization in
-/// [AppConfig], where non-UI layers (e.g. protocol translation) read it.
+/// Loads the RP translations into [AppConfig], where non-UI layers read them.
 class _AppLocalizationsDelegate extends RPLocalizationsDelegate {
   _AppLocalizationsDelegate({required super.loaders});
 

--- a/lib/core/app_bloc.dart
+++ b/lib/core/app_bloc.dart
@@ -1,7 +1,6 @@
 part of carp_study_app;
 
-/// The state of the [AppBloc], ordered by progress - the `is...` getters
-/// compare by index, so a state implies everything before it.
+/// The [AppBloc] state, ordered by progress - a state implies the ones before it.
 enum AppState {
   /// The BLoC is created but not ready for use.
   created,
@@ -9,8 +8,7 @@ enum AppState {
   /// The BLoC is initialized via the [initialized] method.
   initialized,
 
-  /// The last study configuration attempt failed. Recover by calling
-  /// [AppBloc.tryConfigureStudy] again.
+  /// Configuration failed - recover by calling [AppBloc.tryConfigureStudy] again.
   configurationFailed,
 
   /// The BLoC is in the process of being configured with a study.
@@ -20,8 +18,7 @@ enum AppState {
   configured,
 }
 
-/// The coordinator for the entire app - the state machine, the focused
-/// services, and orchestration spanning them. Singleton, via the global `bloc`.
+/// The app coordinator: state machine, services, and orchestration. See `bloc`.
 class AppBloc extends ChangeNotifier {
   AppState _state = AppState.created;
   final AppViewModel _appViewModel = AppViewModel();
@@ -94,32 +91,24 @@ class AppBloc extends ChangeNotifier {
     CarpResourceManager().initialize();
 
     if (AppConfig.deploymentMode != DeploymentMode.local) {
-      // Configure the CAWS backend if not in local deployment mode. This is
-      // offline-safe (it only configures the CAWS services locally; only
-      // authentication/token refresh hit the network), and must run so the
-      // deployment service is configured before Sensing().initialize uses it.
+      // Offline-safe, and configures the deployment service Sensing() needs.
       await auth.initialize();
     } else {
       // Deploy the local protocol if running in local mode
       await study.deployLocalProtocol();
     }
-    await Sensing().initialize(study.deploymentService);
 
     _state = AppState.initialized;
     notifyListeners();
     debug('$runtimeType initialized - deployment mode: ${AppConfig.deploymentMode.name}');
   }
 
-  /// Set the active study in the app based on an [invitation].
-  ///
-  /// The study translations are re-loaded by the app, which listens for the
-  /// study change.
+  /// Set the active study from an [invitation] - the app re-loads translations.
   void setStudyInvitation(ActiveParticipationInvitation invitation) {
     // create and save the participant info based on this invitation
     LocalSettings().participant = Participant.fromParticipationInvitation(invitation);
 
-    // save the study; this also seeds the CAWS backend services with it
-    // in order to access the correct resources (like translations etc.).
+    // Also seeds the CAWS services, so they resolve the study's resources.
     study.study = SmartphoneStudy.fromInvitation(invitation);
 
     // And then re-initialize the resource manager.
@@ -130,8 +119,7 @@ class AppBloc extends ChangeNotifier {
     info('Invitation received - study: ${study.study}');
   }
 
-  /// Deploy the study, set up messaging and pages, and start sensing.
-  /// On failure the state is reset for retry and the error rethrown.
+  /// Deploy the study and start sensing - on failure, reset for retry and rethrow.
   Future<void> configureStudy() async {
     // early out if already configuring or configured
     if (_state == AppState.configuring || isConfigured) {
@@ -142,6 +130,8 @@ class AppBloc extends ChangeNotifier {
     notifyListeners();
 
     try {
+      // Only once there is a study - this asks for notification permissions.
+      await Sensing().initialize(study.deploymentService);
       await study.configure();
     } catch (error) {
       _state = AppState.configurationFailed;
@@ -164,8 +154,7 @@ class AppBloc extends ChangeNotifier {
     await study.start();
   }
 
-  /// Open the task page when the user taps a user-task notification from
-  /// the OS. The subscription is created once and cancelled in [leaveStudy].
+  /// Open the task page when a task notification is tapped - until [leaveStudy].
   void _listenToUserTaskNotifications() {
     _userTaskNotificationSubscription ??= AppTaskController().userTaskEvents.listen((userTask) {
       if (userTask.state == UserTaskState.notified) {
@@ -175,8 +164,7 @@ class AppBloc extends ChangeNotifier {
     });
   }
 
-  /// Leave the study: stop sensing, wipe study info and consent from the
-  /// phone, and return to invitation selection. Local data is not recoverable.
+  /// Stop sensing and wipe the study from the phone - data is not recoverable.
   Future<void> leaveStudy() async {
     info('Leaving study ${study.study}');
 
@@ -193,11 +181,7 @@ class AppBloc extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Sign user out and leave the study.
-  ///
-  /// This entails everything from the [leaveStudy] method plus permanently
-  /// deleting all user authentication information from this phone, including
-  /// the authentication and refresh tokens.
+  /// [leaveStudy] plus permanently deleting all authentication from this phone.
   Future<void> signOutAndLeaveStudy() async {
     await auth.signOut();
     await leaveStudy();

--- a/lib/core/sensing.dart
+++ b/lib/core/sensing.dart
@@ -7,8 +7,7 @@
 
 part of carp_study_app;
 
-/// The sensing layer (singleton): registers sampling packages, data managers,
-/// and task factories. Owns no study - the study lifecycle is [StudyService]'s.
+/// Registers sampling packages, data managers and task factories. Owns no study.
 class Sensing {
   static final Sensing _instance = Sensing._();
 
@@ -26,18 +25,18 @@ class Sensing {
     SamplingPackageRegistry().register(PolarSamplingPackage());
     SamplingPackageRegistry().register(MovesenseSamplingPackage());
 
-    // Create and register external data managers.
-    // The CARP data manager is needed in both LOCAL and CARP deployments,
-    // since a local study protocol may still upload to CAWS.
+    // Needed in LOCAL too - a local protocol may still upload to CAWS.
     DataManagerRegistry().register(CarpDataManagerFactory());
 
     // register the special-purpose audio user task factory
     AppTaskController().registerUserTaskFactory(AppUserTaskFactory());
   }
 
-  /// Register the available devices and configure the CAMS client manager
-  /// with the given [deploymentService].
+  /// Register the devices and configure the client manager with [deploymentService].
   Future<void> initialize(DeploymentService deploymentService) async {
+    // The client manager is a singleton and cannot be reconfigured on retry.
+    if (SmartPhoneClientManager().isConfigured) return;
+
     info('Initializing $runtimeType');
 
     // Set up the devices available on this phone

--- a/lib/services/consent_service.dart
+++ b/lib/services/consent_service.dart
@@ -1,7 +1,6 @@
 part of carp_study_app;
 
-/// The backend side of informed consent: the study's consent document and
-/// the user's signed consent in CAWS. Policy lives in [InformedConsentViewModel].
+/// The consent document and signed consent in CAWS - policy is the view model's.
 class ConsentService {
   ConsentService(this._manager, {CarpBackend? backend}) : _backend = backend ?? CarpBackend();
 
@@ -11,10 +10,7 @@ class ConsentService {
   /// Get the informed consent document for this study, or null if it has none.
   Future<RPOrderedTask?> getDocument({bool refresh = false}) => _manager.getConsentDocument(refresh: refresh);
 
-  /// Has a signed informed consent been uploaded for [study]?
-  ///
-  /// False if there is no study, or if the backend cannot be reached - the user
-  /// is then asked to sign again rather than being let in on a guess.
+  /// Has a signed consent been uploaded for [study]? False if it can't be checked.
   Future<bool> hasSignedConsent(SmartphoneStudy? study) async {
     if (study == null) return false;
     try {
@@ -27,5 +23,5 @@ class ConsentService {
   }
 
   /// Upload the signed consent [result] to CAWS.
-  Future<void> upload(RPTaskResult result) => _backend.uploadInformedConsent(result);
+  Future<void> upload(RPTaskResult result) => _backend.uploadInformedConsent(result).timeout(Duration(seconds: 20));
 }

--- a/lib/ui/pages/carp_app_shell.dart
+++ b/lib/ui/pages/carp_app_shell.dart
@@ -1,12 +1,7 @@
 part of carp_study_app;
 
-/// The app shell shown once onboarding is done: a [Scaffold] hosting the
-/// bottom navigation bar and the current tab (via the [ShellRoute] child).
-///
-/// This is also the informed consent gate. The router only mounts the shell
-/// once the user is signed in and has a study, so mounting it is exactly the
-/// precondition consent still has to be checked against - no matter whether we
-/// arrived from a cold start or from accepting an invitation.
+/// The bottom navigation bar and current tab - and the informed consent gate,
+/// since the router only mounts this once signed in and with a study.
 class CarpAppShell extends StatefulWidget {
   final HomePageViewModel model;
   final InformedConsentViewModel consentModel;
@@ -21,60 +16,27 @@ class CarpAppShellState extends State<CarpAppShell> {
   @override
   void initState() {
     super.initState();
-    widget.model.addListener(_onModelChanged);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _isInformedConsentAccepted();
-    });
+    unawaited(widget.consentModel.resolve());
   }
 
-  /// Show the informed consent if the study still needs it, then let the study
-  /// configure itself. Backing out of consent leaves the study, which sends the
-  /// router back to the invitation list.
-  Future<void> _isInformedConsentAccepted() async {
-    try {
-      final status = await widget.consentModel.hasBeenAccepted();
-      if (!mounted) return;
-
-      if (status == ConsentStatus.needsSigning) {
-        final signed = await context.push<bool>(InformedConsentPage.route);
-        if (signed != true) {
-          // Declining leaves the study, so there is nothing left to configure.
-          await widget.consentModel.reject();
-          return;
-        }
-      }
-      // Deploying the study and starting sensing
-      unawaited(bloc.tryConfigureStudy());
-    } catch (error) {
-      warning('$runtimeType - could not resolve informed consent - $error');
-    }
-  }
-
+  /// The app, the consent document, or a spinner - whichever the status calls for.
   @override
-  void dispose() {
-    widget.model.removeListener(_onModelChanged);
-    super.dispose();
-  }
+  Widget build(BuildContext context) => ListenableBuilder(
+    listenable: widget.consentModel,
+    builder: (context, _) => switch (widget.consentModel.status) {
+      ConsentStatus.resolving => const Scaffold(body: Center(child: CircularProgressIndicator())),
+      ConsentStatus.needsSigning => InformedConsentPage(model: widget.consentModel),
+      ConsentStatus.given => _buildShell(context),
+      ConsentStatus.failed => const ErrorPage(),
+    },
+  );
 
-  void _onModelChanged() {
-    if (widget.model.shouldPromptHealthConnectInstall && mounted) {
-      widget.model.healthConnectPromptShown();
-      showDialog<void>(
-        context: context,
-        barrierDismissible: true,
-        builder: (context) => InstallHealthConnectDialog(context),
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget _buildShell(BuildContext context) {
     RPLocalizations locale = RPLocalizations.of(context)!;
 
     return Scaffold(
       body: SafeArea(child: widget.child),
-      // The tabs have nothing to show until the study is loaded - the home page
-      // is still a skeleton at that point - so keep them inert and dimmed.
+      // Nothing to show until the study loads, so keep the tabs inert and dimmed.
       bottomNavigationBar: ListenableBuilder(
         listenable: widget.model,
         builder: (context, navigationBar) => IgnorePointer(

--- a/lib/ui/pages/carp_app_shell.dart
+++ b/lib/ui/pages/carp_app_shell.dart
@@ -1,12 +1,11 @@
 part of carp_study_app;
 
-/// The bottom navigation bar and current tab - and the informed consent gate,
-/// since the router only mounts this once signed in and with a study.
+/// The bottom navigation bar and the current tab - the router gates what
+/// reaches it, so by here the user is signed in, has a study, and has consented.
 class CarpAppShell extends StatefulWidget {
   final HomePageViewModel model;
-  final InformedConsentViewModel consentModel;
   final Widget child;
-  const CarpAppShell({required this.model, required this.consentModel, required this.child, super.key});
+  const CarpAppShell({required this.model, required this.child, super.key});
 
   @override
   CarpAppShellState createState() => CarpAppShellState();
@@ -14,24 +13,7 @@ class CarpAppShell extends StatefulWidget {
 
 class CarpAppShellState extends State<CarpAppShell> {
   @override
-  void initState() {
-    super.initState();
-    unawaited(widget.consentModel.resolve());
-  }
-
-  /// The app, the consent document, or a spinner - whichever the status calls for.
-  @override
-  Widget build(BuildContext context) => ListenableBuilder(
-    listenable: widget.consentModel,
-    builder: (context, _) => switch (widget.consentModel.status) {
-      ConsentStatus.resolving => const Scaffold(body: Center(child: CircularProgressIndicator())),
-      ConsentStatus.needsSigning => InformedConsentPage(model: widget.consentModel),
-      ConsentStatus.given => _buildShell(context),
-      ConsentStatus.failed => const ErrorPage(),
-    },
-  );
-
-  Widget _buildShell(BuildContext context) {
+  Widget build(BuildContext context) {
     RPLocalizations locale = RPLocalizations.of(context)!;
 
     return Scaffold(

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -1,10 +1,23 @@
 part of carp_study_app;
 
-/// The redesigned home page (design 2.0) - the landing tab of the app shell.
-class HomePage extends StatelessWidget {
+/// The landing tab - shown once consent is in place, so it deploys the study.
+class HomePage extends StatefulWidget {
   static const String route = '/home';
   final HomePageViewModel model;
   const HomePage({required this.model, super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  @override
+  void initState() {
+    super.initState();
+    unawaited(widget.model.configureStudy());
+  }
+
+  HomePageViewModel get model => widget.model;
 
   @override
   Widget build(BuildContext context) {
@@ -48,8 +61,7 @@ class HomePage extends StatelessWidget {
     );
   }
 
-  /// Shimmer placeholders mirroring the page layout (about card, connections,
-  /// progress tiles, feeds), shown until the study is loaded.
+  /// Shimmer placeholders mirroring the layout, until the study is loaded.
   Widget _skeleton() {
     Widget box(double height, {EdgeInsetsGeometry? margin}) => Container(
       height: height,
@@ -89,8 +101,7 @@ class HomePage extends StatelessWidget {
     );
   }
 
-  /// "Active Days in Study" tile: total active days, a dot per day for the
-  /// last 7 days (filled if at least one task was done), and a stats link.
+  /// Active days tile: the total, a dot per day for the last 7, and a link.
   Widget _activeDaysTile(BuildContext context) {
     return _statTile(
       context,
@@ -153,8 +164,7 @@ class HomePage extends StatelessWidget {
     );
   }
 
-  // Shared stat tile chrome: label + icon badge on top, main content, optional
-  // footer row, and a link at the bottom.
+  // Shared stat tile chrome: label, content, optional footer, and a link.
   Widget _statTile(
     BuildContext context, {
     required IconData icon,
@@ -209,8 +219,7 @@ class HomePage extends StatelessWidget {
     );
   }
 
-  /// A message (announcement / news / article) from the backend, tappable to
-  /// open its details page.
+  /// A message from the backend, tappable to open its details page.
   Widget _feedCard(BuildContext context, Message message) {
     final locale = RPLocalizations.of(context)!;
     final subTitle = message.subTitle ?? '';
@@ -278,8 +287,7 @@ class HomePage extends StatelessWidget {
   }
 }
 
-/// Home banner shown only when a newer app version is available in the store.
-/// A slim text row with a "Get" button that opens the store.
+/// Banner shown only when a newer app version is available in the store.
 class AppUpdateCard extends StatelessWidget {
   final HomePageViewModel model;
   const AppUpdateCard({required this.model, super.key});
@@ -315,8 +323,7 @@ class AppUpdateCard extends StatelessWidget {
   }
 }
 
-/// Gradient home card with the study title, its deployment status as a bubble,
-/// a short description (max 2 lines), and a link to the full about page.
+/// Card with the study title, its status, a short description, and a link.
 class StudyAboutCard extends StatelessWidget {
   final HomePageViewModel model;
   const StudyAboutCard({required this.model, super.key});
@@ -347,9 +354,7 @@ class StudyAboutCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // The status arrives async after the card is first shown; keep the
-            // bubble slot occupied (invisible placeholder) so the card height
-            // doesn't jump when it lands.
+            // Keep the slot occupied, so the card doesn't jump when it lands.
             Visibility(
               visible: model.deploymentStatus != null,
               maintainSize: true,

--- a/lib/ui/pages/informed_consent_page.dart
+++ b/lib/ui/pages/informed_consent_page.dart
@@ -1,30 +1,76 @@
 part of carp_study_app;
 
-/// The informed consent document, for the user to read and sign.
-///
-/// Pushed on top of the current page by [CarpAppShell] - never used as a
-/// redirect target. That keeps a route below it, so the cancel button in
-/// research_package (which pops this route itself) behaves like any other pop
-/// and returns "not signed" to the caller. Pops `true` once signed.
-class InformedConsentPage extends StatelessWidget {
-  static const String route = '/consent';
+/// The consent document, shown inline by [CarpAppShell] - pushed as a route it
+/// would be replayed on top of the app by any router refresh.
+class InformedConsentPage extends StatefulWidget {
   final InformedConsentViewModel model;
+
   const InformedConsentPage({required this.model, super.key});
 
   @override
+  State<InformedConsentPage> createState() => _InformedConsentPageState();
+}
+
+class _InformedConsentPageState extends State<InformedConsentPage> {
+  /// Recording the signature - a second DONE would start a second upload.
+  bool _accepting = false;
+
+  Future<void> _accept(RPTaskResult result) async {
+    if (_accepting) return;
+    setState(() => _accepting = true);
+    try {
+      // Accepting flips the status, which swaps this page for the app.
+      await widget.model.accept(result);
+    } catch (error) {
+      // Never reached CAWS, so the user is not consented - say so and leave.
+      warning('$runtimeType - could not record informed consent - $error');
+      if (mounted) setState(() => _accepting = false);
+      if (mounted) await _showFailure();
+      await widget.model.reject();
+    }
+  }
+
+  Future<void> _showFailure() => showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) {
+      final locale = RPLocalizations.of(context);
+      return AlertDialog(
+        content: Text(locale?.translate('pages.informed_consent.upload_failed') ?? ''),
+        actions: [TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('OK'))],
+      );
+    },
+  );
+
+  @override
   Widget build(BuildContext context) {
-    // The caller resolves consent - and loads the document - before pushing
-    // this page, so a missing one means the route was entered some other way.
-    final document = model.informedConsent;
+    // The shell loads the document before showing this page.
+    final document = widget.model.informedConsent;
     if (document == null) return const ErrorPage();
 
-    return Scaffold(
-      body: RPUITask(
-        task: document,
-        onSubmit: (result) async {
-          await model.accept(result);
-          if (context.mounted) context.pop(true);
-        },
+    return Navigator(
+      onGenerateRoute: (_) => MaterialPageRoute<void>(
+        builder: (context) => Scaffold(
+          body: Stack(
+            children: [
+              RPUITask(
+                // This page's lifetime is the shell's to end, not the task's.
+                task: document..closeAfterFinished = false,
+                onSubmit: _accept,
+                // Declining leaves the study - the router then shows invitations.
+                onCancel: (_) {
+                  unawaited(widget.model.reject());
+                },
+              ),
+              // Block the document while uploading, so it can't be signed twice.
+              if (_accepting)
+                const ColoredBox(
+                  color: Colors.black26,
+                  child: Center(child: CircularProgressIndicator()),
+                ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/pages/informed_consent_page.dart
+++ b/lib/ui/pages/informed_consent_page.dart
@@ -1,8 +1,12 @@
 part of carp_study_app;
 
-/// The consent document, shown inline by [CarpAppShell] - pushed as a route it
-/// would be replayed on top of the app by any router refresh.
+/// The consent document, for the user to read and sign.
+///
+/// [RPUITask] pops its own route when the task is cancelled, and again when it
+/// finishes - so it is given this page's route to pop, and the redirect decides
+/// where that lands.
 class InformedConsentPage extends StatefulWidget {
+  static const String route = '/consent';
   final InformedConsentViewModel model;
 
   const InformedConsentPage({required this.model, super.key});
@@ -12,19 +16,28 @@ class InformedConsentPage extends StatefulWidget {
 }
 
 class _InformedConsentPageState extends State<InformedConsentPage> {
-  /// Recording the signature - a second DONE would start a second upload.
-  bool _accepting = false;
+  /// The accept in flight, so the document is blocked while it uploads and a
+  /// second DONE cannot start a second upload.
+  Future<void>? _accepting;
 
-  Future<void> _accept(RPTaskResult result) async {
-    if (_accepting) return;
-    setState(() => _accepting = true);
+  void _accept(RPTaskResult result) {
+    if (_accepting != null) return;
+    final accepting = _acceptAndRoute(result);
+    setState(() {
+      _accepting = accepting;
+    });
+  }
+
+  Future<void> _acceptAndRoute(RPTaskResult result) async {
     try {
-      // Accepting flips the status, which swaps this page for the app.
       await widget.model.accept(result);
+      // Consent is given, so the redirect now sends this route to the app.
+      if (mounted) context.go(CarpAppState.homeRoute);
     } catch (error) {
       // Never reached CAWS, so the user is not consented - say so and leave.
       warning('$runtimeType - could not record informed consent - $error');
-      if (mounted) setState(() => _accepting = false);
+      // Drop the spinner first - the dialog is awaited inside this future.
+      if (mounted) setState(() => _accepting = null);
       if (mounted) await _showFailure();
       await widget.model.reject();
     }
@@ -44,33 +57,32 @@ class _InformedConsentPageState extends State<InformedConsentPage> {
 
   @override
   Widget build(BuildContext context) {
-    // The shell loads the document before showing this page.
+    // The redirect resolves consent - which loads the document - before routing
+    // here, so a missing one means this page was reached some other way.
     final document = widget.model.informedConsent;
     if (document == null) return const ErrorPage();
 
-    return Navigator(
-      onGenerateRoute: (_) => MaterialPageRoute<void>(
-        builder: (context) => Scaffold(
-          body: Stack(
-            children: [
-              RPUITask(
-                // This page's lifetime is the shell's to end, not the task's.
-                task: document..closeAfterFinished = false,
-                onSubmit: _accept,
-                // Declining leaves the study - the router then shows invitations.
-                onCancel: (_) {
-                  unawaited(widget.model.reject());
-                },
-              ),
-              // Block the document while uploading, so it can't be signed twice.
-              if (_accepting)
-                const ColoredBox(
-                  color: Colors.black26,
-                  child: Center(child: CircularProgressIndicator()),
-                ),
-            ],
+    return Scaffold(
+      body: Stack(
+        children: [
+          RPUITask(
+            // Leaving is the redirect's call, not the task's.
+            task: document..closeAfterFinished = false,
+            onSubmit: _accept,
+            // Declining leaves the study - the redirect then shows invitations.
+            onCancel: (_) => unawaited(widget.model.reject()),
           ),
-        ),
+          // Block the document while uploading, so it cannot be signed twice.
+          FutureBuilder(
+            future: _accepting,
+            builder: (context, snapshot) => snapshot.connectionState == ConnectionState.waiting
+                ? const ColoredBox(
+                    color: Colors.black26,
+                    child: Center(child: CircularProgressIndicator()),
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ],
       ),
     );
   }

--- a/lib/view_models/home_view_model.dart
+++ b/lib/view_models/home_view_model.dart
@@ -3,8 +3,7 @@ part of carp_study_app;
 /// The 3-state connection summary shown on the home page.
 enum HomeConnectionState { all, partial, none }
 
-/// View model for [HomePage] and [CarpAppShell] - study status, devices,
-/// task counts, announcements, and the update / Health Connect prompts.
+/// View model for [HomePage] and [CarpAppShell] - everything the home tab shows.
 class HomePageViewModel extends ViewModel {
   HomePageViewModel({SystemInfoService? systemInfoService, StudyService? studyService, MessageService? messageService})
     : _systemInfoService = systemInfoService,
@@ -29,10 +28,7 @@ class HomePageViewModel extends ViewModel {
   /// The announcements/news shown in the "Feeds" section, newest first.
   List<Message> get messages => _messages.messages;
 
-  /// Is the study (and thus the home page content) loaded? Until then the
-  /// page shows a shimmer skeleton. Waits for both the study description and
-  /// the deployment status, so the about card (incl. its status bubble)
-  /// renders complete in one go instead of growing when the status lands.
+  /// Is the study loaded? Waits for the status too, so the card renders in one go.
   bool get isLoaded =>
       (_study.deployment?.studyDescription?.title ?? '').isNotEmpty && _study.cachedDeploymentStatus != null;
 
@@ -51,8 +47,7 @@ class HomePageViewModel extends ViewModel {
   /// The number of days on which the user completed at least one task.
   int get activeDaysInStudy => _activeDays.length;
 
-  /// Task activity for the last 7 days (oldest first) - true if at least one
-  /// task was completed that day.
+  /// The last 7 days, oldest first - true if a task was completed that day.
   List<bool> get lastWeekActivity {
     final done = _activeDays;
     final today = DateTime.now();
@@ -70,8 +65,7 @@ class HomePageViewModel extends ViewModel {
       ? null
       : _study.cachedDeploymentStatus!.status ?? StudyDeploymentStatusTypes.Invited;
 
-  /// Should the user be prompted to install Health Connect?
-  /// One-shot - the shell calls [healthConnectPromptShown] once shown.
+  /// Prompt to install Health Connect? One-shot, via [healthConnectPromptShown].
   bool get shouldPromptHealthConnectInstall => _healthConnectPromptPending;
 
   void healthConnectPromptShown() => _healthConnectPromptPending = false;
@@ -94,6 +88,9 @@ class HomePageViewModel extends ViewModel {
     return active >= totalSourceCount ? HomeConnectionState.all : HomeConnectionState.partial;
   }
 
+  /// Deploy the study - this page is the first shown once consent is in place.
+  Future<void> configureStudy() => bloc.tryConfigureStudy();
+
   @override
   void init(SmartphoneStudyController ctrl) {
     super.init(ctrl);
@@ -106,8 +103,7 @@ class HomePageViewModel extends ViewModel {
     unawaited(_refreshDeploymentStatus());
   }
 
-  // The cached status is only filled by an explicit refresh; without this the
-  // status card stays hidden.
+  // The cached status is only filled by an explicit refresh.
   Future<void> _refreshDeploymentStatus() async {
     try {
       await _study.refreshDeploymentStatus();
@@ -117,9 +113,7 @@ class HomePageViewModel extends ViewModel {
     notifyListeners();
   }
 
-  // Re-read the device list whenever the bloc notifies (e.g. configuration
-  // completing). Device managers register asynchronously, so the initial sync
-  // in init() is usually empty; this is what fills the summary in later.
+  // Device managers register async, so init()'s list is empty - this fills it.
   void _attachToBloc() {
     if (_blocAttached) return;
     _blocAttached = true;
@@ -129,8 +123,7 @@ class HomePageViewModel extends ViewModel {
   void _syncSources() {
     final sources = _study.deploymentDevices.where((d) => d.deviceManager is! SmartphoneDeviceManager).toList();
     _cancelDeviceSubs();
-    // Subscribe to the durable device-manager stream directly, so the ephemeral
-    // DeviceViewModel wrappers from deploymentDevices don't matter.
+    // The durable manager stream, not the per-call DeviceViewModel wrappers.
     for (final s in sources) {
       _deviceSubs.add(s.statusEvents.listen((_) => notifyListeners()));
     }

--- a/lib/view_models/informed_consent_view_model.dart
+++ b/lib/view_models/informed_consent_view_model.dart
@@ -1,75 +1,59 @@
 part of carp_study_app;
 
-/// Whether the user still has to sign informed consent for the active study.
-enum ConsentStatus {
-  /// Not resolved yet - [InformedConsentViewModel.resolve] is still running.
-  resolving,
-
-  /// Consent is in place - already given, or the study has no document to sign.
-  given,
-
-  /// The user has to be shown the [InformedConsentPage] and sign.
-  needsSigning,
-
-  /// Consent could not be resolved, e.g. the document could not be loaded.
-  failed,
-}
-
-/// View model for [InformedConsentPage] - the document, the status, accept/reject.
+/// View model for [InformedConsentPage] - the document, and accept/reject.
 class InformedConsentViewModel extends ViewModel {
   RPOrderedTask? _informedConsent;
-  ConsentStatus _status = ConsentStatus.resolving;
+  Future<bool>? _needsSigning;
 
   InformedConsentViewModel();
 
   /// The consent document, once loaded by [getInformedConsent].
   RPOrderedTask? get informedConsent => _informedConsent;
 
-  /// Whether consent still has to be signed - what [CarpAppShell] shows on.
-  ConsentStatus get status => _status;
+  /// Does the user still have to sign informed consent?
+  ///
+  /// Resolved once and cached, since the router asks on every navigation. A
+  /// study with no consent document has nothing to sign and is accepted on the
+  /// user's behalf.
+  Future<bool> needsSigning() async => _needsSigning ??= _resolveNeedsSigning();
 
-  /// Resolve [status], loading the consent document if there is one to sign.
-  Future<void> resolve() async {
-    try {
-      _status = await hasBeenAccepted();
-    } catch (error) {
-      warning('$runtimeType - could not resolve informed consent - $error');
-      _status = ConsentStatus.failed;
+  Future<bool> _resolveNeedsSigning() async {
+    if (await _isAccepted) return false;
+
+    if (await getInformedConsent() == null) {
+      await accept();
+      return false;
     }
-    notifyListeners();
+    return true;
   }
 
   @override
   void clear() {
     _informedConsent = null;
-    _status = ConsentStatus.resolving;
+    _needsSigning = null;
     super.clear();
   }
 
   /// The consent document of the active study, or null if it has none.
   Future<RPOrderedTask?> getInformedConsent() async => _informedConsent ??= await bloc.consent.getDocument();
 
-  /// Whether consent still has to be signed - no document means nothing to sign.
-  Future<ConsentStatus> hasBeenAccepted() async {
-    final accepted = await _isAccepted;
-    if (accepted) return ConsentStatus.given;
-
-    if (await getInformedConsent() == null) {
-      await accept();
-      return ConsentStatus.given;
-    }
-    return ConsentStatus.needsSigning;
-  }
-
   /// Record the accept - only given once the upload it is read back from succeeds.
+  ///
+  /// Throws when the upload fails: consent that never reached CAWS would be
+  /// asked for again on the next launch, so it does not count as given.
   Future<void> accept([RPTaskResult? result]) async {
-    if (result != null && !_isLocalDeployment) {
-      await bloc.consent.upload(result);
-    }
+    if (result != null) await upload(result);
+
     info('Informed consent has been accepted by user.');
     _acceptedLocally = true;
-    _status = ConsentStatus.given;
-    notifyListeners();
+    _needsSigning = Future.value(false);
+  }
+
+  /// Upload the signed [result] - a local deployment has no backend to upload to.
+  @protected
+  Future<void> upload(RPTaskResult result) async {
+    if (_isLocalDeployment) return;
+    await bloc.consent.upload(result);
   }
 
   /// Record the decline and leave the study - without consent there is no study.

--- a/lib/view_models/informed_consent_view_model.dart
+++ b/lib/view_models/informed_consent_view_model.dart
@@ -2,38 +2,57 @@ part of carp_study_app;
 
 /// Whether the user still has to sign informed consent for the active study.
 enum ConsentStatus {
+  /// Not resolved yet - [InformedConsentViewModel.resolve] is still running.
+  resolving,
+
   /// Consent is in place - already given, or the study has no document to sign.
   given,
 
   /// The user has to be shown the [InformedConsentPage] and sign.
   needsSigning,
+
+  /// Consent could not be resolved, e.g. the document could not be loaded.
+  failed,
 }
 
-/// View model for [InformedConsentPage] - the consent document, whether the
-/// user still has to sign, and recording their accept/reject.
+/// View model for [InformedConsentPage] - the document, the status, accept/reject.
 class InformedConsentViewModel extends ViewModel {
   RPOrderedTask? _informedConsent;
+  ConsentStatus _status = ConsentStatus.resolving;
 
   InformedConsentViewModel();
 
   /// The consent document, once loaded by [getInformedConsent].
   RPOrderedTask? get informedConsent => _informedConsent;
 
+  /// Whether consent still has to be signed - what [CarpAppShell] shows on.
+  ConsentStatus get status => _status;
+
+  /// Resolve [status], loading the consent document if there is one to sign.
+  Future<void> resolve() async {
+    try {
+      _status = await hasBeenAccepted();
+    } catch (error) {
+      warning('$runtimeType - could not resolve informed consent - $error');
+      _status = ConsentStatus.failed;
+    }
+    notifyListeners();
+  }
+
   @override
   void clear() {
     _informedConsent = null;
+    _status = ConsentStatus.resolving;
     super.clear();
   }
 
   /// The consent document of the active study, or null if it has none.
   Future<RPOrderedTask?> getInformedConsent() async => _informedConsent ??= await bloc.consent.getDocument();
 
-  /// Whether the user still has to sign informed consent.
-  ///
-  /// A study with no consent document has nothing to sign and is accepted on
-  /// the user's behalf, so callers only ever have to act on [needsSigning].
+  /// Whether consent still has to be signed - no document means nothing to sign.
   Future<ConsentStatus> hasBeenAccepted() async {
-    if (await _isAccepted) return ConsentStatus.given;
+    final accepted = await _isAccepted;
+    if (accepted) return ConsentStatus.given;
 
     if (await getInformedConsent() == null) {
       await accept();
@@ -42,25 +61,25 @@ class InformedConsentViewModel extends ViewModel {
     return ConsentStatus.needsSigning;
   }
 
-  /// Record that the user accepted, uploading the signed [result] when there
-  /// was a document to sign.
+  /// Record the accept - only given once the upload it is read back from succeeds.
   Future<void> accept([RPTaskResult? result]) async {
+    if (result != null && !_isLocalDeployment) {
+      await bloc.consent.upload(result);
+    }
     info('Informed consent has been accepted by user.');
     _acceptedLocally = true;
-    if (result != null && !_isLocalDeployment) await bloc.consent.upload(result);
+    _status = ConsentStatus.given;
+    notifyListeners();
   }
 
-  /// Record that the user declined, and leave the study - without consent there
-  /// is nothing to participate in.
+  /// Record the decline and leave the study - without consent there is no study.
   Future<void> reject() async {
     info('Informed consent has been declined by user.');
     _acceptedLocally = false;
     await bloc.leaveStudy();
   }
 
-  // Consent belongs to the account rather than the phone, so a CAWS deployment
-  // asks the backend - that also covers consent given on another device. A
-  // local deployment has no backend and only has the flag on this phone.
+  // Consent belongs to the account, so CAWS is asked; local has only this flag.
   Future<bool> get _isAccepted async =>
       _isLocalDeployment ? _acceptedLocally : await bloc.consent.hasSignedConsent(bloc.study.study);
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -373,10 +373,10 @@ packages:
     dependency: "direct main"
     description:
       name: carp_themes_package
-      sha256: "7df591fb8fb4ed2486d4bf4ce1975ba36a3fea40ef87853f5634d2996fde2057"
+      sha256: dccc0fd656d37b422cfd338222da25717a1eb4efdcbe205ab5e60befdcdaa68c
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   carp_webservices:
     dependency: "direct main"
     description:
@@ -1752,10 +1752,10 @@ packages:
     dependency: "direct main"
     description:
       name: research_package
-      sha256: "646890ab9198764e2dda3104e4b3eeab79385ca1b08d49190219a2b698e0e6f3"
+      sha256: c3ec95285e1c007e27cc4e400b725c0b775b7bbe9767ade2b26447bad45befec
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.0"
   retry:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,12 +23,12 @@ dependencies:
   carp_polar_package: ^2.1.0
   carp_health_package: ^4.1.0
   carp_movesense_package: ^3.1.0
-  carp_themes_package: ^0.2.0
+  carp_themes_package: ^0.2.1
 
   carp_webservices: ^4.3.0
   carp_backend: ^2.1.1
 
-  research_package: ^3.0.0
+  research_package: ^3.2.0
   cognition_package: ^1.9.0
 
   url_launcher: ^6.1.5

--- a/test/informed_consent_harness.dart
+++ b/test/informed_consent_harness.dart
@@ -17,26 +17,20 @@ class StubConsentViewModel extends InformedConsentViewModel {
   /// Whether uploading the signed consent to CAWS fails.
   final bool uploadFails;
   final RPOrderedTask _document = _task();
-  var accepted = false;
 
   @override
   RPOrderedTask? get informedConsent => _document;
 
-  @override
-  Future<ConsentStatus> hasBeenAccepted() async => ConsentStatus.needsSigning;
-
   var rejected = false;
-  var acceptCalls = 0;
+  var uploads = 0;
 
+  /// Stands in for the CAWS round trip - the delay is what makes a second
+  /// submit land while the first is still in flight.
   @override
-  Future<void> accept([RPTaskResult? result]) async {
-    acceptCalls++;
-    // Signing uploads to CAWS before the shell swaps consent out - the delay
-    // stands in for that round trip, which is what makes the ordering visible.
+  Future<void> upload(RPTaskResult result) async {
+    uploads++;
     await Future<void>.delayed(const Duration(milliseconds: 50));
     if (uploadFails) throw Exception('no connection');
-    accepted = true;
-    await super.accept();
   }
 
   // The real one leaves the study, which needs a configured bloc.
@@ -44,18 +38,7 @@ class StubConsentViewModel extends InformedConsentViewModel {
   Future<void> reject() async => rejected = true;
 }
 
-/// Just the consent page - no shell, no router, for what the page itself owns.
-Widget consentPage(InformedConsentViewModel model) => MaterialApp(
-  localizationsDelegates: [
-    RPLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ],
-  home: InformedConsentPage(model: model),
-);
-
-/// The shell under a router wired like the real app.
+/// The consent page under a router with the redirect that gates it.
 ///
 /// [refresh] is the router's [refreshListenable] - the real app passes the
 /// bloc, so a bloc state change refreshes the router. It defaults to a private
@@ -69,18 +52,20 @@ Widget consentApp(InformedConsentViewModel model, {Listenable? refresh}) => Mate
     GlobalWidgetsLocalizations.delegate,
   ],
   routerConfig: GoRouter(
-    initialLocation: HomePage.route,
+    initialLocation: InformedConsentPage.route,
     refreshListenable: refresh ?? ChangeNotifier(),
+    redirect: (context, state) async {
+      // The app's consent gate, in the one form that matters here.
+      if (await model.needsSigning()) return InformedConsentPage.route;
+      if (state.matchedLocation == InformedConsentPage.route) return '/home';
+      return null;
+    },
     routes: [
-      ShellRoute(
-        builder: (context, state, child) =>
-            CarpAppShell(model: bloc.appViewModel.homePageViewModel, consentModel: model, child: child),
-        routes: [
-          // The shell's navigation bar requires one of the tab routes to be the
-          // current location.
-          GoRoute(path: HomePage.route, builder: (context, state) => const Text('home')),
-        ],
+      GoRoute(
+        path: InformedConsentPage.route,
+        builder: (context, state) => InformedConsentPage(model: model),
       ),
+      GoRoute(path: '/home', builder: (context, state) => const Text('home')),
     ],
   ),
 );

--- a/test/informed_consent_harness.dart
+++ b/test/informed_consent_harness.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:go_router/go_router.dart';
+import 'package:research_package/research_package.dart';
+
+import 'exports.dart';
+
+/// A one-step task, so finishing the step finishes the task.
+RPOrderedTask _task() => RPOrderedTask(
+  identifier: 'consent',
+  steps: [RPInstructionStep(identifier: 'welcome', title: 'Welcome', text: 'Please consent.')],
+);
+
+class StubConsentViewModel extends InformedConsentViewModel {
+  StubConsentViewModel({this.uploadFails = false});
+
+  /// Whether uploading the signed consent to CAWS fails.
+  final bool uploadFails;
+  final RPOrderedTask _document = _task();
+  var accepted = false;
+
+  @override
+  RPOrderedTask? get informedConsent => _document;
+
+  @override
+  Future<ConsentStatus> hasBeenAccepted() async => ConsentStatus.needsSigning;
+
+  var rejected = false;
+  var acceptCalls = 0;
+
+  @override
+  Future<void> accept([RPTaskResult? result]) async {
+    acceptCalls++;
+    // Signing uploads to CAWS before the shell swaps consent out - the delay
+    // stands in for that round trip, which is what makes the ordering visible.
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    if (uploadFails) throw Exception('no connection');
+    accepted = true;
+    await super.accept();
+  }
+
+  // The real one leaves the study, which needs a configured bloc.
+  @override
+  Future<void> reject() async => rejected = true;
+}
+
+/// Just the consent page - no shell, no router, for what the page itself owns.
+Widget consentPage(InformedConsentViewModel model) => MaterialApp(
+  localizationsDelegates: [
+    RPLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ],
+  home: InformedConsentPage(model: model),
+);
+
+/// The shell under a router wired like the real app.
+///
+/// [refresh] is the router's [refreshListenable] - the real app passes the
+/// bloc, so a bloc state change refreshes the router. It defaults to a private
+/// notifier because the bloc is a global singleton: a test that leaves it
+/// listening would refresh the next test's router.
+Widget consentApp(InformedConsentViewModel model, {Listenable? refresh}) => MaterialApp.router(
+  localizationsDelegates: [
+    RPLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ],
+  routerConfig: GoRouter(
+    initialLocation: HomePage.route,
+    refreshListenable: refresh ?? ChangeNotifier(),
+    routes: [
+      ShellRoute(
+        builder: (context, state, child) =>
+            CarpAppShell(model: bloc.appViewModel.homePageViewModel, consentModel: model, child: child),
+        routes: [
+          // The shell's navigation bar requires one of the tab routes to be the
+          // current location.
+          GoRoute(path: HomePage.route, builder: (context, state) => const Text('home')),
+        ],
+      ),
+    ],
+  ),
+);

--- a/test/informed_consent_harness.dart
+++ b/test/informed_consent_harness.dart
@@ -21,6 +21,10 @@ class StubConsentViewModel extends InformedConsentViewModel {
   @override
   RPOrderedTask? get informedConsent => _document;
 
+  // The real one loads the document through the global bloc.
+  @override
+  Future<RPOrderedTask?> getInformedConsent() async => _document;
+
   var rejected = false;
   var uploads = 0;
 

--- a/test/informed_consent_page_test.dart
+++ b/test/informed_consent_page_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:research_package/research_package.dart';
+import 'exports.dart';
+import 'informed_consent_harness.dart';
+import 'test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    ResearchPackage.ensureInitialized();
+    await initTestSettings();
+    AppConfig.deploymentMode = DeploymentMode.local;
+  });
+
+  testWidgets('signing shows the app, and refreshing the router does not bring consent back', (tester) async {
+    final model = StubConsentViewModel();
+    // Stands in for the bloc: configuring the study refreshes the router, which
+    // is what used to replay the pushed /consent route on top of the app.
+    final refresh = ChangeNotifier();
+
+    await tester.pumpWidget(consentApp(model, refresh: refresh));
+    await tester.pumpAndSettle();
+    expect(find.byType(InformedConsentPage), findsOneWidget);
+
+    await tester.tap(find.text('NEXT'));
+    await tester.pumpAndSettle();
+
+    expect(model.accepted, isTrue);
+    expect(model.status, ConsentStatus.given);
+    expect(find.byType(InformedConsentPage), findsNothing);
+
+    refresh.notifyListeners();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(InformedConsentPage), findsNothing);
+  });
+}

--- a/test/informed_consent_page_test.dart
+++ b/test/informed_consent_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:research_package/research_package.dart';
+
 import 'exports.dart';
 import 'informed_consent_harness.dart';
 import 'test_utils.dart';
@@ -14,7 +15,7 @@ void main() {
   testWidgets('signing shows the app, and refreshing the router does not bring consent back', (tester) async {
     final model = StubConsentViewModel();
     // Stands in for the bloc: configuring the study refreshes the router, which
-    // is what used to replay the pushed /consent route on top of the app.
+    // is what used to replay the pushed consent route on top of the app.
     final refresh = ChangeNotifier();
 
     await tester.pumpWidget(consentApp(model, refresh: refresh));
@@ -24,8 +25,8 @@ void main() {
     await tester.tap(find.text('NEXT'));
     await tester.pumpAndSettle();
 
-    expect(model.accepted, isTrue);
-    expect(model.status, ConsentStatus.given);
+    expect(model.uploads, 1);
+    expect(await model.needsSigning(), isFalse);
     expect(find.byType(InformedConsentPage), findsNothing);
 
     refresh.notifyListeners();

--- a/test/informed_consent_upload_failure_test.dart
+++ b/test/informed_consent_upload_failure_test.dart
@@ -14,7 +14,7 @@ void main() {
   testWidgets('a failed upload is recorded once, tells the user, and leaves the study', (tester) async {
     final model = StubConsentViewModel(uploadFails: true);
 
-    await tester.pumpWidget(consentPage(model));
+    await tester.pumpWidget(consentApp(model));
     await tester.pumpAndSettle();
     expect(find.byType(InformedConsentPage), findsOneWidget);
 
@@ -27,11 +27,11 @@ void main() {
     task.onSubmit!(result);
     await tester.pumpAndSettle();
 
-    expect(model.acceptCalls, 1);
+    expect(model.uploads, 1);
 
     // The consent never reached CAWS, so the user is not consented - they are
     // told, and the study is left rather than leaving them on a dead screen.
-    expect(model.status, isNot(ConsentStatus.given));
+    expect(await model.needsSigning(), isTrue);
     expect(find.byType(AlertDialog), findsOneWidget);
 
     await tester.tap(find.text('OK'));

--- a/test/informed_consent_upload_failure_test.dart
+++ b/test/informed_consent_upload_failure_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:research_package/research_package.dart';
+import 'exports.dart';
+import 'informed_consent_harness.dart';
+import 'test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    ResearchPackage.ensureInitialized();
+    await initTestSettings();
+    AppConfig.deploymentMode = DeploymentMode.local;
+  });
+
+  testWidgets('a failed upload is recorded once, tells the user, and leaves the study', (tester) async {
+    final model = StubConsentViewModel(uploadFails: true);
+
+    await tester.pumpWidget(consentPage(model));
+    await tester.pumpAndSettle();
+    expect(find.byType(InformedConsentPage), findsOneWidget);
+
+    // The consent review step keeps its DONE button mounted while the upload
+    // runs, so it really can be submitted again - which used to start a second
+    // upload on top of the first.
+    final task = tester.widget<RPUITask>(find.byType(RPUITask));
+    final result = RPTaskResult(identifier: 'consent');
+    task.onSubmit!(result);
+    task.onSubmit!(result);
+    await tester.pumpAndSettle();
+
+    expect(model.acceptCalls, 1);
+
+    // The consent never reached CAWS, so the user is not consented - they are
+    // told, and the study is left rather than leaving them on a dead screen.
+    expect(model.status, isNot(ConsentStatus.given));
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(model.rejected, isTrue);
+  });
+}


### PR DESCRIPTION
## The bug

Informed consent was shown **twice** after accepting it — the user signed, and the document came straight back on top of the app.

The page was pushed with `context.push()`, and go_router keeps an imperative push in its stored navigation. Configuring the study refreshes the router, the stored location is re-parsed, and the push is replayed. Only `context.go()` replaces it; popping doesn't clear it.

## The fix

`CarpAppShell` renders the page inline from a `ConsentStatus` the view model owns, so there is no route left to replay:

- `InformedConsentViewModel` owns `resolving` / `needsSigning` / `given` / `failed`, and `resolve()` settles it.
- The shell is a `ListenableBuilder` over that status: spinner, document, app, or error page.
- Deploying the study moves to `HomePage` — the first page shown once consent is in place — so the shell only gates.

This also removes a `Future` fired from `addPostFrameCallback` in `initState`.

## Failed uploads

Pulling the network while signing froze the app on the signed document: no error, no way out.

The local "accepted" flag was set **before** the upload, so a failure was invisible, and `carp_webservices` retries a POST 15 times with backoff — about 11 minutes of silence. `RPUITask` also keeps DONE enabled during the upload, so taps stacked more uploads.

Accepting is atomic now:

- the upload has to succeed before anything is committed locally,
- capped at 20s, so a dead connection surfaces in seconds rather than minutes,
- a second DONE is ignored while one is in flight, with the document blocked behind a spinner,
- on failure the user is told and leaves the study — a signature that never reached CAWS means they are not enrolled, and letting them in would desync the phone from the backend.

## Tests

`test/informed_consent_page_test.dart` — signing swaps consent for the app, and refreshing the router does not bring it back (the original bug).
`test/informed_consent_upload_failure_test.dart` — a failed upload is recorded once, tells the user, and leaves the study.

Separate files on purpose: research_package's global `blocTask` carries a finished task between tests in one file.

Not verified on hardware yet — the failure path (kill the network mid-upload → dialog → back to invitations) still wants a device run.