### PR TITLE
fix: consent cancel, action-named dialogs, and stopping sensing on leave

### DIFF
--- a/lib/core/app_bloc.dart
+++ b/lib/core/app_bloc.dart
@@ -174,7 +174,8 @@ class AppBloc extends ChangeNotifier {
     await _userTaskNotificationSubscription?.cancel();
     _userTaskNotificationSubscription = null;
 
-    // stop sensing and remove all deployment info
+    // stop sensing - including in background - and remove all deployment info
+    await BackgroundSensingService().disconnect();
     await study.remove();
 
     _state = AppState.initialized;

--- a/lib/services/background_sensing_service.dart
+++ b/lib/services/background_sensing_service.dart
@@ -36,6 +36,15 @@ class BackgroundSensingService extends ChangeNotifier {
     await refresh();
   }
 
+  /// Stop the foreground service - there is nothing to sense without a study.
+  Future<void> disconnect() async {
+    if (!_isConnected) return;
+
+    await BackgroundService().disable();
+    _isConnected = false;
+    notifyListeners();
+  }
+
   Future<bool> _start() async {
     final localization = AppConfig.localization;
     return await BackgroundService().initialize(

--- a/lib/ui/pages/informed_consent_page.dart
+++ b/lib/ui/pages/informed_consent_page.dart
@@ -67,7 +67,7 @@ class _InformedConsentPageState extends State<InformedConsentPage> {
         children: [
           RPUITask(
             // Leaving is the redirect's call, not the task's.
-            task: document..closeAfterFinished = false,
+            task: document,
             onSubmit: _accept,
             // Declining leaves the study - the redirect then shows invitations.
             onCancel: (_) => unawaited(widget.model.reject()),

--- a/lib/ui/pages/profile_page.dart
+++ b/lib/ui/pages/profile_page.dart
@@ -224,70 +224,54 @@ class ProfilePageState extends State<ProfilePage> {
     });
   }
 
-  Future<void> _showLogoutConfirmationDialog() {
-    RPLocalizations locale = RPLocalizations.of(context)!;
+  Future<void> _showLogoutConfirmationDialog() => _confirm(
+    actionKey: 'pages.profile.log_out',
+    contentKey: 'pages.profile.log_out.confirmation',
+    onConfirmed: () async {
+      await widget.model.signOutAndLeaveStudy();
+      if (mounted) context.go(CarpAppState.homeRoute);
+    },
+  );
 
-    return showDialog<bool>(
+  Future<void> _showLeaveStudyConfirmationDialog() => _confirm(
+    actionKey: 'pages.profile.leave_study',
+    contentKey: 'pages.profile.leave_study.confirmation',
+    onConfirmed: () async {
+      await widget.model.leaveStudy();
+      if (mounted) context.go(InvitationListPage.route);
+    },
+  );
+
+  /// A destructive confirmation: the action names both the title and the red
+  /// confirm button, so the buttons say what happens instead of YES/NO. The
+  /// dialog closes before [onConfirmed] runs, so the UI is not frozen mid-work.
+  Future<void> _confirm({
+    required String actionKey,
+    required String contentKey,
+    required Future<void> Function() onConfirmed,
+  }) async {
+    final locale = RPLocalizations.of(context)!;
+
+    final confirmed = await showDialog<bool>(
       context: context,
-      builder: (BuildContext builderContext) {
-        return AlertDialog(
-          title: Text(locale.translate("pages.profile.log_out.confirmation")),
-          actions: <Widget>[
-            TextButton(
-              child: Text(locale.translate("NO")),
-              onPressed: () async {
-                if (builderContext.mounted) {
-                  Navigator.of(builderContext).pop();
-                }
-              },
-            ),
-            TextButton(
-              child: Text(locale.translate("YES")),
-              onPressed: () async {
-                if (builderContext.mounted) {
-                  await widget.model.signOutAndLeaveStudy();
-                  builderContext.pop();
-                  builderContext.go(CarpAppState.homeRoute);
-                }
-              },
-            ),
-          ],
-        );
-      },
+      builder: (context) => AlertDialog(
+        title: Text(locale.translate(actionKey)),
+        content: Text(locale.translate(contentKey)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(locale.translate('cancel')),
+          ),
+          TextButton(
+            style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(locale.translate(actionKey)),
+          ),
+        ],
+      ),
     );
-  }
 
-  Future<void> _showLeaveStudyConfirmationDialog() {
-    RPLocalizations locale = RPLocalizations.of(context)!;
-
-    return showDialog<bool>(
-      context: context,
-      builder: (BuildContext builderContext) {
-        return AlertDialog(
-          title: Text(locale.translate("pages.profile.leave_study.confirmation")),
-          actions: <Widget>[
-            TextButton(
-              child: Text(locale.translate("NO")),
-              onPressed: () {
-                if (builderContext.mounted) {
-                  Navigator.of(builderContext).pop();
-                }
-              },
-            ),
-            TextButton(
-              child: Text(locale.translate("YES")),
-              onPressed: () async {
-                if (builderContext.mounted) {
-                  await widget.model.leaveStudy();
-                  builderContext.pop();
-                  builderContext.go(InvitationListPage.route);
-                }
-              },
-            ),
-          ],
-        );
-      },
-    );
+    if (confirmed ?? false) await onConfirmed();
   }
 
   Future<void> _showEnableInternetConnectionDialog() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -373,10 +373,10 @@ packages:
     dependency: "direct main"
     description:
       name: carp_themes_package
-      sha256: "7df591fb8fb4ed2486d4bf4ce1975ba36a3fea40ef87853f5634d2996fde2057"
+      sha256: dccc0fd656d37b422cfd338222da25717a1eb4efdcbe205ab5e60befdcdaa68c
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   carp_webservices:
     dependency: "direct main"
     description:
@@ -1752,10 +1752,10 @@ packages:
     dependency: "direct main"
     description:
       name: research_package
-      sha256: "69297894f3f845b40b34b03f6e7f6aa64aa8d3a18f3e3c4a1f78522051417792"
+      sha256: c3ec95285e1c007e27cc4e400b725c0b775b7bbe9767ade2b26447bad45befec
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.0"
   retry:
     dependency: transitive
     description:

--- a/test/background_sensing_service_test.dart
+++ b/test/background_sensing_service_test.dart
@@ -89,6 +89,16 @@ void main() {
       expect(backgroundCalls, contains('disableBackgroundExecution'));
     });
 
+    test('disconnect stops the foreground service', () async {
+      await BackgroundSensingService().connect();
+      expect(BackgroundSensingService().isConnected, isTrue);
+
+      await BackgroundSensingService().disconnect();
+
+      expect(BackgroundSensingService().isConnected, isFalse);
+      expect(backgroundCalls, contains('disableBackgroundExecution'));
+    });
+
     test('is not supported off Android, so it never starts the service', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 

--- a/test/informed_consent_harness.dart
+++ b/test/informed_consent_harness.dart
@@ -21,6 +21,10 @@ class StubConsentViewModel extends InformedConsentViewModel {
   @override
   RPOrderedTask? get informedConsent => _document;
 
+  // The real one loads the document through the global bloc.
+  @override
+  Future<RPOrderedTask?> getInformedConsent() async => _document;
+
   var rejected = false;
   var uploads = 0;
 

--- a/test/informed_consent_page_test.dart
+++ b/test/informed_consent_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:research_package/research_package.dart';
 
 import 'exports.dart';
@@ -11,6 +12,11 @@ void main() {
     await initTestSettings();
     AppConfig.deploymentMode = DeploymentMode.local;
   });
+
+  // rootBundle caches the translation asset's Future. Created in one test's
+  // FakeAsync zone, it never completes in the next - and Localizations then
+  // never builds the app. Loading fresh per test keeps futures in their zone.
+  setUp(rootBundle.clear);
 
   testWidgets('signing shows the app, and refreshing the router does not bring consent back', (tester) async {
     final model = StubConsentViewModel();
@@ -33,5 +39,23 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(InformedConsentPage), findsNothing);
+  });
+
+  testWidgets('declining rejects without popping the only route', (tester) async {
+    final model = StubConsentViewModel();
+
+    await tester.pumpWidget(consentApp(model));
+    await tester.pumpAndSettle();
+
+    // The close button opens RP's cancel confirmation dialog; LEAVE used to
+    // pop the task's route too - the only one in the stack, crashing go_router.
+    await tester.tap(find.byIcon(Icons.highlight_off));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('LEAVE'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(model.rejected, isTrue);
+    expect(find.byType(InformedConsentPage), findsOneWidget);
   });
 }


### PR DESCRIPTION
> Stacked on #672 — review that first, this diff is on top of it. Base moves along as the stack lands.

Fixes #673

## What

**Dialogs name the action.** The Leave Study and Sign Out confirmations asked NO/YES with the consequence buried in the text. Both now share one `_confirm` helper: CANCEL / **Leave study** (or **Sign out**), and the actual work runs after the dialog closes — so a slow network call no longer freezes an open dialog.

**Declining consent no longer crashes.** research_package 3.2.0 owns the pop (with a `canPop` guard), so the page drops its `closeAfterFinished = false` workaround. Declining as the only route is covered by a test — the go_router "popped the last page" crash case.

**Leaving the study stops the foreground service.** `BackgroundSensingService.disconnect()` is called from `leaveStudy()` — without a study there is nothing to sense.

## Tests

- `informed_consent_page_test.dart` — declining rejects without popping the only route; per-test `rootBundle.clear` keeps localization futures inside their test zone.
- `background_sensing_service_test.dart` — disconnect stops the foreground service.
