### PR TITLE
feat(sensing): background sensing on iOS via the Always location permission

### DIFF
--- a/lib/services/background_sensing_service.dart
+++ b/lib/services/background_sensing_service.dart
@@ -1,7 +1,12 @@
 part of carp_study_app;
 
-/// The Android foreground service keeping data collection running in background.
+/// Keeps data collection running while the app is in the background.
 /// Not part of the deployment - the user connects to it, the app resumes it.
+///
+/// On Android that is a foreground service, gated by the battery optimization
+/// exemption. On iOS there is no such service - continuous location updates
+/// keep the app alive, which needs the "Always" location permission; the
+/// sampling packages already enable background location updates themselves.
 class BackgroundSensingService extends ChangeNotifier {
   static final BackgroundSensingService _instance = BackgroundSensingService._();
   factory BackgroundSensingService() => _instance;
@@ -12,15 +17,26 @@ class BackgroundSensingService extends ChangeNotifier {
   /// Is background sensing running?
   bool get isConnected => _isConnected;
 
-  /// Android only - tests override via [debugDefaultTargetPlatformOverride].
-  bool get isSupported => defaultTargetPlatform == TargetPlatform.android;
+  /// Tests override via [debugDefaultTargetPlatformOverride].
+  bool get isSupported => _isAndroid || defaultTargetPlatform == TargetPlatform.iOS;
 
-  /// Re-read the battery exemption - the truth, and it can be revoked any time.
+  bool get _isAndroid => defaultTargetPlatform == TargetPlatform.android;
+
+  // The exemption (Android) or Always location (iOS) is the truth - both can
+  // be revoked in the phone's settings at any time, so re-read, not remembered.
+  Permission get _permission => _isAndroid ? Permission.ignoreBatteryOptimizations : Permission.locationAlways;
+
+  /// Re-read the platform permission and bring the service in line with it.
   Future<void> refresh() async {
-    var connected = isSupported && await Permission.ignoreBatteryOptimizations.isGranted;
-    if (connected && !BackgroundService().isEnabled) connected = await _start();
-    // Revoked while running - the exemption is gone, so stop the service too.
-    if (!connected && BackgroundService().isEnabled) await BackgroundService().disable();
+    var connected = isSupported && await _permission.isGranted;
+
+    // The foreground service exists only on Android; on iOS the granted
+    // permission is all there is - location updates keep sensing alive.
+    if (_isAndroid) {
+      if (connected && !BackgroundService().isEnabled) connected = await _start();
+      // Revoked while running - the exemption is gone, so stop the service too.
+      if (!connected && BackgroundService().isEnabled) await BackgroundService().disable();
+    }
 
     if (connected != _isConnected) {
       _isConnected = connected;
@@ -28,19 +44,19 @@ class BackgroundSensingService extends ChangeNotifier {
     }
   }
 
-  /// Ask for the battery optimization exemption and start sensing in background.
+  /// Ask for the platform permission and start sensing in background.
   Future<void> connect() async {
     if (!isSupported) return;
 
-    await Permission.ignoreBatteryOptimizations.request();
+    await _permission.request();
     await refresh();
   }
 
-  /// Stop the foreground service - there is nothing to sense without a study.
+  /// Stop background sensing - there is nothing to sense without a study.
   Future<void> disconnect() async {
     if (!_isConnected) return;
 
-    await BackgroundService().disable();
+    if (_isAndroid) await BackgroundService().disable();
     _isConnected = false;
     notifyListeners();
   }

--- a/test/background_sensing_service_test.dart
+++ b/test/background_sensing_service_test.dart
@@ -10,6 +10,7 @@ import 'exports.dart';
 class _FakePermissions extends PermissionHandlerPlatform with MockPlatformInterfaceMixin {
   PermissionStatus status = PermissionStatus.denied;
   int requestCount = 0;
+  final requested = <Permission>[];
 
   @override
   Future<PermissionStatus> checkPermissionStatus(Permission permission) async => status;
@@ -17,6 +18,7 @@ class _FakePermissions extends PermissionHandlerPlatform with MockPlatformInterf
   @override
   Future<Map<Permission, PermissionStatus>> requestPermissions(List<Permission> permissions) async {
     requestCount++;
+    requested.addAll(permissions);
     status = PermissionStatus.granted;
     return {for (final p in permissions) p: status};
   }
@@ -45,8 +47,10 @@ void main() {
     });
 
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
-    // Reset the singleton, which outlives each test.
+    // Reset the singleton, which outlives each test - and drop the calls the
+    // reset itself makes, so each test starts from a clean log.
     await BackgroundSensingService().refresh();
+    backgroundCalls.clear();
   });
 
   tearDown(() {
@@ -99,8 +103,30 @@ void main() {
       expect(backgroundCalls, contains('disableBackgroundExecution'));
     });
 
-    test('is not supported off Android, so it never starts the service', () async {
+    test('on iOS connect asks for Always location, and no foreground service exists', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await BackgroundSensingService().refresh();
+
+      await BackgroundSensingService().connect();
+
+      expect(permissions.requested, [Permission.locationAlways]);
+      expect(BackgroundSensingService().isConnected, isTrue);
+      expect(backgroundCalls, isEmpty);
+    });
+
+    test('on iOS a revoked Always location disconnects', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await BackgroundSensingService().connect();
+      expect(BackgroundSensingService().isConnected, isTrue);
+
+      permissions.status = PermissionStatus.denied;
+      await BackgroundSensingService().refresh();
+
+      expect(BackgroundSensingService().isConnected, isFalse);
+    });
+
+    test('is not supported off the phones, so it never starts', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
 
       await BackgroundSensingService().connect();
 


### PR DESCRIPTION
> Stacked on #672 — review that first, this diff is on top of it.

Fixes #676

## Why

On iOS the app only collected data in the foreground. The `UIBackgroundModes` flags (`location`, `fetch`, `processing`, bluetooth) are already declared in Info.plist, and the sampling packages already call `allowsBackgroundLocationUpdates` — but a background-mode flag only keeps the app alive while the matching API runs, and background location needs the **Always** permission. The app only ever obtained *When In Use*, so iOS suspended it seconds after backgrounding.

## What — client side only, no CAMS change needed

`BackgroundSensingService` becomes cross-platform. The user gesture is the same "connect" on the devices page; what it asks for differs per platform:

| | the truth (re-read, revocable in Settings) | what runs |
|---|---|---|
| Android | battery optimization exemption | CAMS foreground service |
| iOS | **Always** location permission | continuous location updates keep the isolate alive — all probes keep sampling |

- `connect()` requests `Permission.locationAlways` on iOS (Podfile already ships `PERMISSION_LOCATION=1`).
- `refresh()` re-reads the permission on both platforms; revoking disconnects. The foreground service start/stop stays Android-only — CAMS ignores `BackgroundService` on iOS by design.
- The background sensing card on the connections page and the home indicator now show on iOS too, via the existing `isSupported`.

## Why not CAMS

CAMS is already correct: `LocationServiceManager` → `LocationManager.enable()` → `enableBackgroundMode()` sets `CLLocationManager.allowsBackgroundLocationUpdates` when the plist flag is present. The missing piece was purely the Always authorization, which CAMS deliberately leaves to the app ("permissions should be handled on the application level"). Nothing to upstream.

## Tests

`background_sensing_service_test.dart` — on iOS connect asks for Always location and never touches the foreground service; a revoked Always location disconnects; desktop platforms stay unsupported.
