### PR TITLE
fix(android): drop the media permissions open_filex pulls in

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -74,6 +74,19 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
 
+    <!-- open_filex declares the media permissions so it can open files from the
+         gallery. We only open a PDF we wrote to our own cache, so drop them -
+         Play requires a photo/video access declaration for apps that keep them. -->
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_IMAGES"
+        tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_VIDEO"
+        tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_AUDIO"
+        tools:node="remove" />
+
     <!-- Permissions for Health Connect API -->
     <!-- Activity (ACTIVITY_RECOGNITION declared above) -->
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />


### PR DESCRIPTION
Fixes the Play upload rejection:

> Google Api Error: Invalid request - All developers requesting access to the photo and video permissions are required to tell Google Play about the core functionality of their app

## Why

`open_filex` (new in the consent-PDF work, #678) declares `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` and `READ_MEDIA_AUDIO` in its own manifest so it can open files from the gallery. They merged into our bundle, and Play requires a photo and video access declaration from any app that ships them.

We never touch gallery media — the only `OpenFilex.open` call opens a PDF we just wrote to our own cache directory, which needs no permission at all. So the permissions are removed with `tools:node="remove"` rather than declared.

Verified against the merged release manifest (`:app:processReleaseMainManifest`): no `READ_MEDIA_*` remain. `READ_EXTERNAL_STORAGE` stays, capped at `maxSdkVersion="32"`, and is not part of the photo/video declaration.

Foreground service permissions are unchanged: `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_LOCATION`.
