### PR TITLE
fix: photo preview, Android background sensing and iOS permission guidance

### DIFF
--- a/assets/lang/da.json
+++ b/assets/lang/da.json
@@ -153,6 +153,7 @@
   "pages.devices.type.health.access_denied.message": "Der blev ikke givet adgang. For at tillade det skal du gå til: Indstillinger → Apps → CARP Studies → Tilladelser → Sundhed, fitness og wellness → Tillad alle. Træk derefter ned på enhedsskærmen for at opdatere.",
   "pages.devices.location_permission.title": "Tilladelser påkrævet",
   "pages.devices.location_permission.message": "Tilslutning til Bluetooth-enheder i nærheden kræver tilladelserne Enheder i nærheden og Placering. For at tillade dem: gå til Indstillinger → Apps → CARP Studies → Tilladelser, giv de manglende tilladelser, og prøv at forbinde igen.",
+  "pages.devices.background_permission.message": "Baggrundsmåling kræver, at placeringsadgang er sat til Altid. Gå til: Indstillinger → Apps → CARP Studies → Lokalitet, vælg Altid, og vend tilbage til appen. Træk ned på enhedsskærmen for at opdatere.",
   "pages.devices.type.health.instructions.data.steps": "Skridttælling",
   "pages.devices.type.health.instructions.data.heart_rate": "Puls",
   "pages.devices.type.health.instructions.data.exercise": "Træningssessioner",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -242,6 +242,7 @@
   "pages.devices.type.health.access_denied.message": "Access was not granted. To allow it, go to: Settings → Apps → CARP Studies → Permissions → Health, fitness and wellness → Allow all. Then pull down on the devices screen to refresh.",
   "pages.devices.location_permission.title": "Permissions needed",
   "pages.devices.location_permission.message": "Connecting to nearby Bluetooth devices requires the Nearby devices and Location permissions. To allow them, go to: Settings → Apps → CARP Studies → Permissions, grant the missing permissions, then try connecting again.",
+  "pages.devices.background_permission.message": "Background sensing needs location access set to Always. Go to: Settings → Apps → CARP Studies → Location, choose Always, then return to the app and pull down on the devices screen to refresh.",
   "pages.devices.type.health.instructions.data.steps": "Step count",
   "pages.devices.type.health.instructions.data.heart_rate": "Heart rate",
   "pages.devices.type.health.instructions.data.exercise": "Exercise sessions",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -160,6 +160,7 @@
   "pages.home.retry": "Reintentar",
   "pages.devices.location_permission.title": "Permisos necesarios",
   "pages.devices.location_permission.message": "Conectarse a dispositivos Bluetooth cercanos requiere los permisos de Dispositivos cercanos y Ubicación. Para permitirlos, ve a: Ajustes → Apps → CARP Studies → Permisos, concede los permisos que falten e intenta conectarte de nuevo.",
+  "pages.devices.background_permission.message": "La detección en segundo plano necesita el acceso a la ubicación en Siempre. Ve a: Ajustes → Apps → CARP Studies → Ubicación, elige Siempre y vuelve a la app. Desliza hacia abajo en la pantalla de dispositivos para actualizar.",
   "pages.devices.connection.step.scan.searching": "Buscando dispositivos cercanos…\nAsegúrate de que tu dispositivo esté encendido y dentro del alcance.",
   "pages.devices.connection.step.scan.show_all": "¿No ves tu dispositivo? Mostrar todos",
   "pages.devices.connection.step.scan.filtered": "Mostrar solo dispositivos coincidentes",

--- a/lib/core/sensing.dart
+++ b/lib/core/sensing.dart
@@ -47,9 +47,6 @@ class Sensing {
       deploymentService: deploymentService,
       dataCollectorFactory: DeviceController(),
 
-      // Need to ask for permissions all at once on Android.
-      askForPermissions: Platform.isAndroid ? true : false,
-
       // Only resumed - the user connects to it themselves the first time.
       enableBackgroundMode: false,
     );

--- a/lib/services/background_sensing_service.dart
+++ b/lib/services/background_sensing_service.dart
@@ -24,11 +24,21 @@ class BackgroundSensingService extends ChangeNotifier {
 
   // The exemption (Android) or Always location (iOS) is the truth - both can
   // be revoked in the phone's settings at any time, so re-read, not remembered.
-  Permission get _permission => _isAndroid ? Permission.ignoreBatteryOptimizations : Permission.locationAlways;
+  // Android 14+ kills the app if the location-type foreground service starts
+  // without location granted, so that is required too.
+  List<Permission> get _permissions =>
+      _isAndroid ? [Permission.ignoreBatteryOptimizations, Permission.location] : [Permission.locationAlways];
 
-  /// Re-read the platform permission and bring the service in line with it.
+  Future<bool> get _isGranted async {
+    for (final permission in _permissions) {
+      if (!await permission.isGranted) return false;
+    }
+    return true;
+  }
+
+  /// Re-read the platform permissions and bring the service in line with them.
   Future<void> refresh() async {
-    var connected = isSupported && await _permission.isGranted;
+    var connected = isSupported && await _isGranted;
 
     // The foreground service exists only on Android; on iOS the granted
     // permission is all there is - location updates keep sensing alive.
@@ -48,7 +58,7 @@ class BackgroundSensingService extends ChangeNotifier {
   Future<void> connect() async {
     if (!isSupported) return;
 
-    await _permission.request();
+    await _permissions.request();
     await refresh();
   }
 

--- a/lib/ui/pages/device_list_page.dart
+++ b/lib/ui/pages/device_list_page.dart
@@ -179,7 +179,7 @@ class DeviceListPageState extends State<DeviceListPage> {
               leading: const Icon(Icons.autorenew_rounded, size: 30, color: Color(0xff3260A4)),
               title: (locale.translate('pages.devices.type.background.name'), null),
               subtitle: locale.translate('pages.devices.type.background.description'),
-              onTap: connected ? null : () async => await BackgroundSensingService().connect(),
+              onTap: connected ? null : _backgroundSensingClicked,
               trailing: connected
                   ? const Icon(Icons.sensors_rounded, color: _statusSuccess, size: 30)
                   : _connectPill(locale.translate('pages.devices.status.action.connect')),
@@ -295,6 +295,18 @@ class DeviceListPageState extends State<DeviceListPage> {
     await service.deviceManager.connect();
   }
 
+  Future<void> _backgroundSensingClicked() async {
+    await BackgroundSensingService().connect();
+    // If the iOS permission request did not grant Always, explain the Settings fallback.
+    if (!BackgroundSensingService().isConnected && Platform.isIOS && mounted) {
+      await showDialog<void>(
+        context: context,
+        barrierDismissible: true,
+        builder: (context) => _permissionDeniedDialog(context, 'pages.devices.background_permission.message'),
+      );
+    }
+  }
+
   Future<void> _hardwareDeviceClicked(DeviceViewModel device) async {
     // fast out if no Bluetooth
     if (!(await FlutterBluePlus.isSupported)) return;
@@ -319,7 +331,7 @@ class DeviceListPageState extends State<DeviceListPage> {
           await showDialog<void>(
             context: context,
             barrierDismissible: true,
-            builder: (context) => _permissionDeniedDialog(context),
+            builder: (context) => _permissionDeniedDialog(context, 'pages.devices.location_permission.message'),
           );
           return;
         }
@@ -343,12 +355,12 @@ class DeviceListPageState extends State<DeviceListPage> {
     }
   }
 
-  /// Shown when BLE permissions are still denied - points to the app settings.
-  Widget _permissionDeniedDialog(BuildContext context) {
+  /// Explain missing permissions and offer the app settings.
+  Widget _permissionDeniedDialog(BuildContext context, String messageKey) {
     final locale = RPLocalizations.of(context)!;
     return AlertDialog(
       title: Text(locale.translate("pages.devices.location_permission.title")),
-      content: SingleChildScrollView(child: Text(locale.translate("pages.devices.location_permission.message"))),
+      content: SingleChildScrollView(child: Text(locale.translate(messageKey))),
       actions: [
         TextButton(child: Text(locale.translate("cancel")), onPressed: () => Navigator.pop(context)),
         ElevatedButton(

--- a/lib/ui/tasks/display_picture_page.dart
+++ b/lib/ui/tasks/display_picture_page.dart
@@ -21,7 +21,10 @@ class DisplayPicturePageState extends State<DisplayPicturePage> {
   void initState() {
     super.initState();
 
-    // initialize video player controller
+    // only a video can be played - a photo is shown with Image.file, and
+    // handing a JPEG to the video player fails with no extractor found.
+    if (!widget.isVideo) return;
+
     _videoPlayerController = VideoPlayerController.file(File(videoFilePath))
       ..initialize().then((_) {
         setState(() {});
@@ -32,8 +35,8 @@ class DisplayPicturePageState extends State<DisplayPicturePage> {
 
   @override
   void dispose() {
-    super.dispose();
     _videoPlayerController?.dispose();
+    super.dispose();
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -317,18 +317,18 @@ packages:
     dependency: "direct main"
     description:
       name: carp_connectivity_package
-      sha256: "72214fa603b427d2ad0330bf2815c0476b1bf0c90f744ef29d82434d8e107844"
+      sha256: ff6085b33e756218056c5113dac0387b1a061d2d5c2760e759b09e1c8ce5e98e
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   carp_context_package:
     dependency: "direct main"
     description:
       name: carp_context_package
-      sha256: db3446e336ee3f60dcc037d0503690dd898fec3edbd489b6bb18a30c87c3c224
+      sha256: "1fb56bedad8efacb5a8aa9dfad8d00a16e4dd3d9119c4bd91aa66004adb79150"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   carp_core:
     dependency: "direct main"
     description:
@@ -349,10 +349,10 @@ packages:
     dependency: "direct main"
     description:
       name: carp_mobile_sensing
-      sha256: "5a1f38d4068e7bc2e1120e8551344f1d3098030875c72cd6eabf32d823a7d79b"
+      sha256: a98899cc0c07326035bf23f69826808c9bba445b0e6c46ba491d248d2f4713d7
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   carp_movesense_flutter:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
 
   carp_serializable: ^3.0.0
   carp_core: ^2.2.1
-  carp_mobile_sensing: ^2.3.1
-  carp_context_package: ^2.1.0
-  carp_connectivity_package: ^2.2.0
+  carp_mobile_sensing: ^2.4.0
+  carp_context_package: ^2.1.1
+  carp_connectivity_package: ^2.2.1
   carp_survey_package: ^2.1.1
   carp_audio_package: ^2.1.0
   carp_polar_package: ^2.1.0

--- a/test/background_sensing_service_test.dart
+++ b/test/background_sensing_service_test.dart
@@ -75,6 +75,7 @@ void main() {
       await BackgroundSensingService().connect();
 
       expect(permissions.requestCount, 1);
+      expect(permissions.requested, [Permission.ignoreBatteryOptimizations, Permission.location]);
       expect(BackgroundSensingService().isConnected, isTrue);
       expect(backgroundCalls, contains('enableBackgroundExecution'));
       expect(notifications, 1);


### PR DESCRIPTION
Two unrelated crashes found while testing tasks on Android 14+.

### Photo preview crashed the media task
- `DisplayPicturePage.initState` built a `VideoPlayerController` for **every** capture, photo or video. The camera page's photo route never passes `isVideo`, so it defaulted to `false` — `build` correctly rendered `Image.file`, but the controller was already feeding the JPEG to ExoPlayer.
- ExoPlayer's `JpegExtractor` only accepts motion photos, so a plain JPEG failed every sniff and threw `UnrecognizedInputFormatException`.
- Now the controller is only created when `isVideo` is true.
- Also swapped `dispose` to release the controller before `super.dispose()`.

### Background sensing died on Android 14+
- The service asked only for `ignoreBatteryOptimizations`, but the sampling service runs as a **location-type** foreground service (#679). Android 14+ kills the app outright if such a service starts without location granted.
- `_permission` became `_permissions`, so Android asks for `ignoreBatteryOptimizations` **and** `location`; iOS is unchanged (`locationAlways`).
- `refresh()` now treats the service as connected only when *all* required permissions are granted, so revoking either one in system settings turns it back off.

### `askForPermissions: Platform.isAndroid` dropped
It was a no-op - CAMS skipped iOS inside `askForAllPermissions()` anyway. The permission serializer is already in `carp_mobile_sensing`; the iOS skip itself goes away in carp-dk/carp.sensing-flutter#618.

### Test
- `background_sensing_service_test` now asserts *which* permissions are requested, not just how many — the old assertion passed even when location was missing.
- Full suite green (100 tests), analyzer clean.

### iOS background sensing guidance
- On iOS, explain how to enable background sensing when permission remains denied: Settings → Apps → CARP Studies → Location → Always; return and pull down to refresh.
- Reuse the permission dialog and add English, Danish and Spanish guidance, so tapping Connect no longer fails silently.
