### PR TITLE
fix: permission startup handling for 5.0.1

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -97,6 +97,9 @@
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
     <uses-permission android:name="android.permission.health.READ_SKIN_TEMPERATURE" />
 
+    <!-- Sleep - one permission covers sessions and all stages -->
+    <uses-permission android:name="android.permission.health.READ_SLEEP" />
+
     <!-- Historical data (older than 30 days since permission granted) -->
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY" />
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -26,6 +26,9 @@ PODS:
     - Flutter
   - device_info_plus (0.0.1):
     - Flutter
+  - file_picker_darwin (1.0.0):
+    - Flutter
+    - FlutterMacOS
   - Flutter (1.0.0)
   - flutter_activity_recognition (0.0.1):
     - Flutter
@@ -48,7 +51,7 @@ PODS:
     - Flutter
   - flutter_web_auth_2 (5.0.0):
     - Flutter
-  - health (13.3.1):
+  - health (13.3.2):
     - Flutter
   - integration_test (0.0.1):
     - Flutter
@@ -62,6 +65,8 @@ PODS:
   - network_info_plus (0.0.1):
     - Flutter
   - oidc_ios (0.0.1):
+    - Flutter
+  - open_filex (0.0.2):
     - Flutter
   - open_settings_plus (0.0.1):
     - Flutter
@@ -84,6 +89,8 @@ PODS:
   - screen_state (5.0.1):
     - Flutter
   - sensors_plus (0.0.1):
+    - Flutter
+  - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
     - Flutter
@@ -110,6 +117,7 @@ DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - dchs_flutter_beacon (from `.symlinks/plugins/dchs_flutter_beacon/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
+  - file_picker_darwin (from `.symlinks/plugins/file_picker_darwin/darwin`)
   - Flutter (from `Flutter`)
   - flutter_activity_recognition (from `.symlinks/plugins/flutter_activity_recognition/ios`)
   - flutter_appauth (from `.symlinks/plugins/flutter_appauth/ios`)
@@ -126,6 +134,7 @@ DEPENDENCIES:
   - location (from `.symlinks/plugins/location/ios`)
   - network_info_plus (from `.symlinks/plugins/network_info_plus/ios`)
   - oidc_ios (from `.symlinks/plugins/oidc_ios/ios`)
+  - open_filex (from `.symlinks/plugins/open_filex/ios`)
   - open_settings_plus (from `.symlinks/plugins/open_settings_plus/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - pedometer (from `.symlinks/plugins/pedometer/ios`)
@@ -134,6 +143,7 @@ DEPENDENCIES:
   - qr_code_scanner_plus (from `.symlinks/plugins/qr_code_scanner_plus/ios`)
   - screen_state (from `.symlinks/plugins/screen_state/ios`)
   - sensors_plus (from `.symlinks/plugins/sensors_plus/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -169,6 +179,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/dchs_flutter_beacon/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
+  file_picker_darwin:
+    :path: ".symlinks/plugins/file_picker_darwin/darwin"
   Flutter:
     :path: Flutter
   flutter_activity_recognition:
@@ -201,6 +213,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/network_info_plus/ios"
   oidc_ios:
     :path: ".symlinks/plugins/oidc_ios/ios"
+  open_filex:
+    :path: ".symlinks/plugins/open_filex/ios"
   open_settings_plus:
     :path: ".symlinks/plugins/open_settings_plus/ios"
   package_info_plus:
@@ -217,6 +231,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/screen_state/ios"
   sensors_plus:
     :path: ".symlinks/plugins/sensors_plus/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
@@ -238,6 +254,7 @@ SPEC CHECKSUMS:
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   dchs_flutter_beacon: 249ca73abb4ae4aedb0fd29d754ddc39cfa3bc2f
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
+  file_picker_darwin: 5c32d1a83c7cd2e4e2d2eaea629cf830b3b5dc49
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_activity_recognition: 52dfad4c1e9cec99f0841b3ed0efcc9d424b3deb
   flutter_appauth: d4abcf54856e5d8ba82ed7646ffc83245d4aa448
@@ -248,13 +265,14 @@ SPEC CHECKSUMS:
   flutter_sound_core: 7f2626d249d3a57bfa6da892ef7e22d234482c1a
   flutter_timezone: 7c838e17ffd4645d261e87037e5bebf6d38fe544
   flutter_web_auth_2: 646fc9df97a01c59e5eea99b237da2c6360f8439
-  health: 4decf5d74e8f54c58a8c07a385fc72f629a831d9
+  health: 72947bca89ee7906256d6f650db061ca4b2f92c7
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   light: 6490592116da81837a414ef49387bbea7a5ed375
   location: 155caecf9da4f280ab5fe4a55f94ceccfab838f8
   network_info_plus: cf61925ab5205dce05a4f0895989afdb6aade5fc
   oidc_ios: 16966cad509ce6850ca4ca1216c5138bef2a8726
+  open_filex: 432f3cd11432da3e39f47fcc0df2b1603854eff1
   open_settings_plus: d19f91e8a04649358a51c19b484ce2e637149d70
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   pedometer: 6806036696085739f36b4e4e5374135e86220a59
@@ -265,6 +283,7 @@ SPEC CHECKSUMS:
   RxSwift: 4e28be97cbcfeee614af26d83415febbf2bf6f45
   screen_state: e8bc94a9be30050982ffe1bbacc9821bb5287606
   sensors_plus: b70a93b69dafdabd26ce4ac3f4d0529ab9acc4ca
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   SwiftProtobuf: e1b437c8e31a4c5577b643249a0bb62ed4f02153

--- a/lib/core/sensing.dart
+++ b/lib/core/sensing.dart
@@ -47,6 +47,8 @@ class Sensing {
       deploymentService: deploymentService,
       dataCollectorFactory: DeviceController(),
 
+      // Request permissions when connecting, not all at study startup.
+      askForPermissions: false,
       // Only resumed - the user connects to it themselves the first time.
       enableBackgroundMode: false,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: The generic CARP study app.
 publish_to: "none"
 # Bump only the version name for a release; the `+N` build number is ignored by CI
 # (Fastlane auto-increments the Play versionCode; iOS uses the Xcode Cloud build number).
-version: 5.0.0+1
+version: 5.0.1+1
 
 environment:
   sdk: ">=3.8.0 <4.0.0"

--- a/test/expected_permissions_test.dart
+++ b/test/expected_permissions_test.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('study startup does not request all permissions', () {
+    final sensing = File('lib/core/sensing.dart').readAsStringSync();
+    expect(sensing, contains('askForPermissions: false,'));
+  });
+
+  test('Android declares the sleep read permission', () {
+    final manifest = File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+    expect(manifest, contains('android.permission.health.READ_SLEEP'));
+  });
+}


### PR DESCRIPTION
## Changes
- Set `askForPermissions: false` to prevent automatic `askForAllPermissions()` at study startup; permissions are requested when connecting.
- Add Android sleep read permission and refresh the iOS Podfile lockfile.
- Bump app version to `5.0.1+1`.

## Validation
- 20 targeted tests passed (permission configuration, background sensing, sleep/mobility).
- Published CARP dependency upgrades are already on `test` via #685.